### PR TITLE
Multi relay

### DIFF
--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -60,6 +60,7 @@ contract TokenSale is Ownable, SafeMath {
         bytes32 r;
         bytes32 s;
         bytes32 orderHash;
+        bytes32 orderSignedHash;
     }
 
     modifier saleNotInitialized() {
@@ -146,7 +147,8 @@ contract TokenSale is Ownable, SafeMath {
             v: v,
             r: r,
             s: s,
-            orderHash: exchange.getOrderHash(orderAddresses, orderValues)
+            orderHash: exchange.getOrderHash(orderAddresses, orderValues),
+            orderSignedHash: exchange.getOrderSignedHash(orderAddresses, orderValues)
         });
 
         require(order.taker == address(this));
@@ -156,7 +158,7 @@ contract TokenSale is Ownable, SafeMath {
 
         require(isValidSignature(
             order.maker,
-            order.orderHash,
+            order.orderSignedHash,
             v,
             r,
             s

--- a/test/ts/exchange/core.ts
+++ b/test/ts/exchange/core.ts
@@ -348,7 +348,7 @@ contract('Exchange', (accounts: string[]) => {
       assert.equal(expectedFeeMPaid.toString(), logArgs.paidMakerFee.toString());
       assert.equal(expectedFeeTPaid.toString(), logArgs.paidTakerFee.toString());
       assert.equal(expectedTokens, logArgs.tokens);
-      assert.equal(order.params.orderHashHex, logArgs.orderHash);
+      assert.equal(order.params.orderSignedHashHex, logArgs.orderSignedHash);
     });
 
     it('should log 1 event with the correct arguments when order has no feeRecipient', async () => {
@@ -378,7 +378,7 @@ contract('Exchange', (accounts: string[]) => {
       assert.equal(expectedFeeMPaid.toString(), logArgs.paidMakerFee.toString());
       assert.equal(expectedFeeTPaid.toString(), logArgs.paidTakerFee.toString());
       assert.equal(expectedTokens, logArgs.tokens);
-      assert.equal(order.params.orderHashHex, logArgs.orderHash);
+      assert.equal(order.params.orderSignedHashHex, logArgs.orderSignedHash);
     });
 
     it('should throw when taker is specified and order is claimed by other', async () => {
@@ -750,7 +750,7 @@ contract('Exchange', (accounts: string[]) => {
       assert.equal(expectedCancelledMakerTokenAmount.toString(), logArgs.cancelledMakerTokenAmount.toString());
       assert.equal(expectedCancelledTakerTokenAmount.toString(), logArgs.cancelledTakerTokenAmount.toString());
       assert.equal(expectedTokens, logArgs.tokens);
-      assert.equal(order.params.orderHashHex, logArgs.orderHash);
+      assert.equal(order.params.orderSignedHashHex, logArgs.orderSignedHash);
     });
 
     it('should not log events if no value is cancelled', async () => {

--- a/test/ts/exchange/helpers.ts
+++ b/test/ts/exchange/helpers.ts
@@ -64,6 +64,9 @@ contract('Exchange', (accounts: string[]) => {
 
     it('should return true with a valid signature', async () => {
       const success = await exchangeWrapper.isValidSignatureAsync(order);
+      console.log(success)
+      console.log(order.isValidSignature())
+      console.log(order)
       const isValidSignature = order.isValidSignature();
       assert(isValidSignature);
       assert(success);

--- a/util/exchange_wrapper.ts
+++ b/util/exchange_wrapper.ts
@@ -110,7 +110,7 @@ export class ExchangeWrapper {
   public isValidSignatureAsync(order: Order) {
     const isValidSignature = this.exchange.isValidSignature(
       order.params.maker,
-      order.params.orderHashHex,
+      order.params.orderSignedHashHex,
       order.params.v,
       order.params.r,
       order.params.s,

--- a/util/types.ts
+++ b/util/types.ts
@@ -72,6 +72,7 @@ export interface OrderParams {
   expirationTimestampInSec: BigNumber.BigNumber;
   salt: BigNumber.BigNumber;
   orderHashHex?: string;
+  orderSignedHashHex?: string;
   v?: number;
   r?: string;
   s?: string;


### PR DESCRIPTION
Re-work the `orderHash`, removing the fee Recipient and introduce a signed Order hash of `keccak(orderHash, feeRecipient)`

This allows a maker to submit the same order to many different relayers, maximising liquidity.